### PR TITLE
Setuptools fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 python-leetcode==1.0.6
+setuptools==57.5.0
 diskcache
 genanki
 tqdm


### PR DESCRIPTION
setuptools>=58 breaks support for use_2to3 and because of that, pip is unable to get Pystache > 0.5.0 which is needed.